### PR TITLE
feat: 支持在界面配置API凭证

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# 将以下值替换为你在 nowapi 平台申请的凭证
+NOWAPI_APPKEY=your_appkey
+NOWAPI_SIGN=your_sign

--- a/README.md
+++ b/README.md
@@ -8,3 +8,28 @@
 - 近十年每月的汇率折线图
 
 ![echarts](https://github.com/amazing-fish/dollar2yuan/assets/71763696/464fbc31-24d7-4bba-9122-b0b00fe96327)
+
+## 凭证配置方式
+
+在启动桌面应用前，需要先准备好 [nowapi](https://www.nowapi.com/api/finance.rate_history) 提供的 `appkey` 与 `sign`：
+
+1. **环境变量方式**（推荐）：
+
+   ```bash
+   export NOWAPI_APPKEY="你的appkey"
+   export NOWAPI_SIGN="你的sign"
+   python main.py
+   ```
+
+2. **`.env` 文件方式**：在项目根目录创建 `.env`（或复制 `.env.example`）并填入内容，程序启动时会自动读取：
+
+   ```env
+   NOWAPI_APPKEY=你的appkey
+   NOWAPI_SIGN=你的sign
+   ```
+
+   若需在其他环境中复用，也可以搭配 `python-dotenv` 等工具在运行前自动加载。
+
+3. **界面手动输入**：运行程序后，可直接在界面顶部的输入框中填写 `AppKey` 与 `Sign`，点击“查询”按钮即可保存于当前会话。
+
+若凭证未配置或输入，程序会提示用户补全信息。

--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+import os
+from pathlib import Path
 from tkinter import messagebox, ttk
 import tkinter as tk
 import requests
@@ -174,12 +176,27 @@ def show_data_with_echarts(appkey, sign, days):
 
 # GUI界面
 def create_gui():
-    appkey = 'APPKEY'  # 替换成您的appkey
-    sign = 'SIGN'  # 替换成您的sign
+    env_defaults = {}
+    env_file = Path('.env')
+    if env_file.exists():
+        for line in env_file.read_text(encoding='utf-8').splitlines():
+            stripped = line.strip()
+            if not stripped or stripped.startswith('#') or '=' not in stripped:
+                continue
+            key, value = stripped.split('=', 1)
+            env_defaults[key.strip()] = value.strip().strip('"').strip("'")
+
+    appkey_var = tk.StringVar(value=os.getenv('NOWAPI_APPKEY', env_defaults.get('NOWAPI_APPKEY', '')))
+    sign_var = tk.StringVar(value=os.getenv('NOWAPI_SIGN', env_defaults.get('NOWAPI_SIGN', '')))
 
     def on_submit():
+        appkey = appkey_var.get().strip()
+        sign = sign_var.get().strip()
         days = days_entry.get()
         ht_type = ht_type_combo.get()
+        if not appkey or not sign:
+            messagebox.showerror("错误", "请先输入 AppKey 和 Sign 凭证！")
+            return
         if not days.isdigit():
             messagebox.showerror("错误", "请输入有效的天数！")
             return
@@ -199,17 +216,27 @@ def create_gui():
     root = tk.Tk()
     root.title("汇率查询工具")
 
-    ttk.Label(root, text="近x天:").grid(row=0, column=0, padx=10, pady=10)
-    days_entry = ttk.Entry(root)
-    days_entry.grid(row=0, column=1, padx=10, pady=10)
+    ttk.Label(root, text="AppKey:").grid(row=0, column=0, padx=10, pady=10, sticky='e')
+    appkey_entry = ttk.Entry(root, textvariable=appkey_var)
+    appkey_entry.grid(row=0, column=1, padx=10, pady=10, sticky='we')
 
-    ttk.Label(root, text="数据类型:").grid(row=1, column=0, padx=10, pady=10)
+    ttk.Label(root, text="Sign:").grid(row=1, column=0, padx=10, pady=10, sticky='e')
+    sign_entry = ttk.Entry(root, textvariable=sign_var, show='*')
+    sign_entry.grid(row=1, column=1, padx=10, pady=10, sticky='we')
+
+    ttk.Label(root, text="近x天:").grid(row=2, column=0, padx=10, pady=10, sticky='e')
+    days_entry = ttk.Entry(root)
+    days_entry.grid(row=2, column=1, padx=10, pady=10, sticky='we')
+
+    ttk.Label(root, text="数据类型:").grid(row=3, column=0, padx=10, pady=10, sticky='e')
     ht_type_combo = ttk.Combobox(root, values=['HT1D', 'HT1W', 'HT1M', 'HTHY', 'HT1Y'], state="readonly")
-    ht_type_combo.grid(row=1, column=1, padx=10, pady=10)
+    ht_type_combo.grid(row=3, column=1, padx=10, pady=10, sticky='we')
     ht_type_combo.current(0)
 
     submit_btn = ttk.Button(root, text="查询", command=on_submit)
-    submit_btn.grid(row=2, column=0, columnspan=2, padx=10, pady=10)
+    submit_btn.grid(row=4, column=0, columnspan=2, padx=10, pady=10)
+
+    root.columnconfigure(1, weight=1)
 
     root.mainloop()
 


### PR DESCRIPTION
## 摘要
- 在 GUI 中增加 AppKey/Sign 输入框，支持从环境变量或 .env 文件读取初始值
- 启动时校验凭证输入并通过弹窗提示缺失信息
- 新增 .env.example 并更新 README，说明多种凭证配置方式

## 测试
- python -m compileall main.py

------
https://chatgpt.com/codex/tasks/task_e_68d931eea1ec8328bbb2cdf775e5ff12