### PR TITLE
修复 Tk 变量初始化顺序避免默认根窗口错误

### DIFF
--- a/main.py
+++ b/main.py
@@ -266,6 +266,9 @@ def create_gui():
 
     env_defaults = load_local_env()
 
+    root = tk.Tk()
+    root.title("汇率查询工具")
+
     api_key_var = tk.StringVar(value=os.getenv('ALPHAVANTAGE_API_KEY', env_defaults.get('ALPHAVANTAGE_API_KEY', '')))
     outputsize_var = tk.StringVar(value=os.getenv('ALPHAVANTAGE_OUTPUTSIZE', env_defaults.get('ALPHAVANTAGE_OUTPUTSIZE', 'compact')) or 'compact')
 
@@ -332,9 +335,6 @@ def create_gui():
             return
 
         show_data_with_echarts(data, title="自定义数据走势")
-
-    root = tk.Tk()
-    root.title("汇率查询工具")
 
     # 启动即尝试读取本地基础数据（可被 on_submit/show_base_data 使用）
     base_data = load_base_data()


### PR DESCRIPTION
## 总结
- 调整 `create_gui` 中 `tk.Tk()` 与 `root.title(...)` 的位置，确保 `StringVar` 在主窗口创建之后初始化，从而避免未绑定主窗口的错误

## 测试
- python main.py（受限于无 DISPLAY 环境导致失败）

------
https://chatgpt.com/codex/tasks/task_e_68d9793e6d30832883e49fde2b657819